### PR TITLE
Overhaul cross-talk-check.sh

### DIFF
--- a/cross-talk-check.sh
+++ b/cross-talk-check.sh
@@ -1,13 +1,37 @@
 #!/bin/bash 
 #provided as-is with no warranties for help in debugging/mitigating OVN-kube failure condition on OpenShift
-#A dot (.) represents a successful connection
-#A failure will be logged explicitly as: connection failure calling to peer ${TARGET}, ${TARGETHOST} - call timed out!
+#output is provided in sections group by client pod
+#the number of failres over the number of connection attempts will be reported for each target for any given client
+#specific details about failed connections will be logged to the file specified by $PROBEERR
 #Reasons for error condition may include: IPSEC configuration issues, OVN-kube db fragmentation/issues,
 #6081/UDP port denial between peer nodes or between host infrastructure, or ACL/firewall rule packet denials
 #This script validates that geneve traffic can flow between nodes
- 
+
+usage() {
+  echo "Usage: $0 <attempts>"
+  echo ""
+  echo "Tests TCP connectivity between dns-default pods in the openshift-dns namespace."
+  echo ""
+  echo "Arguments"
+  echo "----"
+  echo "    attempts - The number of connection attempts to make between a source pod and target pod (default: 3)"
+}
+
+ATTEMPTS="${1:-3}"
+
+if ! [[ "${ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid number of attempts: ${ATTEMPTS}"
+  usage
+  exit 1
+fi
+
 DATE=$(date +"%Y-%m-%d-%H-%M") 
-PROBELOG=${DATE}_healthprobe.out 
+PROBELOG=${DATE}_healthprobe.out
+PROBEERR=${DATE}_healthprobe.err
+
+#handle signals with exit codes aligning with the gentleman's agreement described at https://tldp.org/LDP/abs/html/exitcodes.html
+#immediately exit on SIGINT to regain control of the shell
+trap "exit 130" INT
  
 healthprobe() { 
 ##https://everything.curl.dev/cmdline/exitcode.html 
@@ -16,23 +40,69 @@ healthprobe() {
 ##Extend the timeout or try changing something else that allows curl to finish its operation faster. 
 ##Often, this happens due to network and remote server situations that you cannot affect locally. 
 
-echo "now querying all dns-peers for cross-talk capacity..." 
-##iterate over all peer pods; get the exit result of a connection; if it's a timeout (28) then log the NAME of the NODE and the result timeout; otherwise skip + add a dot to progress log. 
-for SOURCE in $(oc get pod -n openshift-dns | grep dns-default | awk {'print $1'}); do 
-  #define client host node:
-  CLIENTHOST=$(oc get pod -n openshift-dns -o wide | grep ${SOURCE} | awk {'print $7'})
-	echo "Current client: ${SOURCE}, ${CLIENTHOST}"
-    for TARGET in $(oc get pod -n openshift-dns -o wide | grep dns-default | awk {'print $6'}); do 
-      #define TARGET host node:
-      TARGETHOST=$(oc get pod -n openshift-dns -o wide | grep ${TARGET} | awk {'print $7'})
-      #check conditional call to peer 
-      RESULT=$(oc -n openshift-dns rsh $SOURCE curl --connect-timeout 1 -kv -s ${TARGET}:5353/health 2>&1 )
-      if [[ $? -eq 28 ]]
-      then 
-        echo "connection failure calling to peer ${TARGET}, ${TARGETHOST} - call timed out!"
-      else dummyvalue=true; fi; echo "."; 
+echo "now querying all dns-peers for cross-talk capacity..."
+echo ""
+
+#pre-fetch the name, IP, and node info from all dns-default pods in the cluster
+DNSPODS="$(oc get pod -n openshift-dns -l dns.operator.openshift.io/daemonset-dns=default -o jsonpath='{range .items[*]}{@.metadata.name}{":"}{@.status.podIP}{":"}{@.spec.nodeName}{"\n"}{end}')"
+
+#iterate over all peer pods; get the exit result of a connection; log the number of failed connection attempts for each peer 
+for SOURCE in ${DNSPODS}; do
+  #define source info:
+  SOURCEPOD="$(echo ${SOURCE} | cut -d ':' -f 1)"
+  SOURCEIP="$(echo ${SOURCE} | cut -d ':' -f 2)"
+  SOURCEHOST="$(echo ${SOURCE} | cut -d ':' -f 3)"
+
+  echo "===="
+  echo "Current client pod: ${SOURCEPOD} (${SOURCEIP}) on host ${SOURCEHOST}"
+  echo "===="
+
+  for TARGET in ${DNSPODS}; do
+    # skip self chatter
+    if [[ "${TARGET}" = "${SOURCE}" ]]
+    then
+      continue
+    fi
+
+    #define target info:
+    TARGETPOD="$(echo ${TARGET} | cut -d ':' -f 1)"
+    TARGETIP="$(echo ${TARGET} | cut -d ':' -f 2)"
+    TARGETHOST="$(echo ${TARGET} | cut -d ':' -f 3)"
+
+    #check conditional call to peer
+    FAILURE="0"
+    for i in $(seq 1 ${ATTEMPTS})
+    do
+      RESULT="$(oc -n openshift-dns -c dns exec "${SOURCEPOD}" -- curl --connect-timeout 1 -kv -s http://"${TARGETIP}":8080/health 2>&1)"
+      CODE="$?"
+      if [[ "${CODE}" -ne 0 ]]
+      then
+        FAILURE="$(expr "${FAILURE}" + 1)"
+
+        echo "----" >&2
+        echo "Source: ${SOURCEPOD} (${SOURCEIP}) - ${SOURCEHOST}" >&2
+        echo "Target: ${TARGETPOD} (${TARGETIP}) - ${TARGETHOST}" >&2
+        echo "Attempt: ${i}" >&2
+        echo "Exit Code: ${CODE}" >&2
+        echo "" >&2
+        echo "${RESULT}" >&2
+        echo "----" >&2
+        echo "" >&2
+      fi
     done
-done | tee $PROBELOG 
+
+    echo "${TARGETPOD} (${TARGETIP}) on host ${TARGETHOST} - Failure rate: ${FAILURE} / ${ATTEMPTS}"
+  done
+
+  echo "";
+done 2> $PROBEERR  | tee $PROBELOG
+
+NEW_DNSPODS="$(oc get pod -n openshift-dns -l dns.operator.openshift.io/daemonset-dns=default -o jsonpath='{range .items[*]}{@.metadata.name}{":"}{@.status.podIP}{":"}{@.spec.nodeName}{"\n"}{end}')"
+
+if [[ "${NEW_DNSPODS}" != "${DNSPODS}" ]]
+then
+  echo "WARNING: dns-default pods changed during the execution of this script, results may not be completely accurate"
+fi
 }
 
 healthprobe


### PR DESCRIPTION
This PR makes a number of changes to cross-talk-check.sh:
- Removes usage of `grep` and `awk` on `oc` commands to use label selectors and jsonpath instead, as edge cases would break the script like if the pods had restarts
- Pre-fetches the list of DNS pods and their info to reduce OpenShift API calls
- Switches the targeted endpoint from the UDP 5353 port to the TCP 8080 port used by the dns-default pods' liveness probe
- Considers any non-zero curl exit code as a failure instead of only considering timeouts (28)
- Logs current connection details and curl output to the file specified by `$PROBEERR` when a failure is detected
- Adds a SIGINT handler to the script to exit immediately
- Implements the capability to perform multiple connection attempts for each source-target pair to determine failure rate (default currently set to 3)
- Updates output to display the target and failure rate grouped by source

Functionality was tested against a 4.20 cluster with one broken target and all new features worked appropriately.